### PR TITLE
Add ruff to pre-commit configuration with all rules enabled

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.6
+    hooks:
+      - id: ruff
+        args: [--fix, --select, ALL]
+      - id: ruff-format


### PR DESCRIPTION
## Summary
- Add `.pre-commit-config.yaml` with standard pre-commit hooks
- Configure ruff with `--select ALL` to enable all available linting rules
- Include ruff-format for automatic code formatting

## Test plan
- [x] Created and tested pre-commit configuration locally
- [x] Verified hooks run successfully with `pre-commit run --all-files`
- [ ] Review and merge to enable comprehensive linting for the project

🤖 Generated with [Claude Code](https://claude.ai/code)