### PR TITLE
Add PyVista X virtual framebuffer initialization

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -8,6 +8,8 @@ import pyvista as pv
 import streamlit as st
 from stpyvista import stpyvista
 
+pv.start_xvfb()
+
 st.set_page_config(page_title="FElupe Beam Example", layout="wide")
 
 st.title("🏗️ Cantilever Beam Under Gravity")


### PR DESCRIPTION
## Summary
• Initialize Xvfb for PyVista to enable headless rendering in Streamlit deployments
• Ensures compatibility with deployment environments that lack display servers

## Test plan
- [x] Verify Streamlit app runs locally with the change
- [x] Test deployment functionality in headless environment
- [x] Confirm PyVista rendering works without display server

🤖 Generated with [Claude Code](https://claude.ai/code)